### PR TITLE
Fix repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/dominictarr/pull-ping",
   "repository": {
     "type": "git",
-    "url": "git://github.com/dominictarr/pull-ping-pong"
+    "url": "git://github.com/dominictarr/pull-ping"
   },
   "dependencies": {
     "pull-pushable": "^2.0.0",


### PR DESCRIPTION
I was trying to download Git repos for all of my dependencies programmatically and noticed that this still had an old URL (broken on the npm registry).